### PR TITLE
Import of G_Suite_-_Admin_Champions

### DIFF
--- a/automation/dev/okta/application/terragrunt.hcl
+++ b/automation/dev/okta/application/terragrunt.hcl
@@ -1,0 +1,35 @@
+include {
+    path = find_in_parent_folders("env.hcl")
+}
+terraform {
+    source = "git::git@github.com:BackMarket/world-common.git//okta-applications-saml?ref=okta-applications-saml-1.0.0"
+}
+inputs = {
+    label = "G Suite - Admin Champions"
+    logo = "./logo.png"
+    preconfigured_app = "google"
+    auto_submit_toolbar = true
+    accessibility_self_service = false
+    app_links_json = jsonencode({"accounts":false,"calendar":false,"drive":false,"keep":false,"mail":true,"sites":false})
+    app_settings_json = jsonencode({"afwOnly":false,"domain":"backmarket.fr"})
+    assertion_signed = false
+    hide_web = false
+    hide_ios = false
+    honor_force_authn = false
+    response_signed = false
+    saml_version = "2.0"
+    user_name_template = "String.toLowerCase(\"admin-champions@backmarket.com\")"
+    user_name_template_push_status = "PUSH"
+    user_name_template_type = "CUSTOM"
+    attribute_statements = [{"filter_type": "REGEX", "filter_value": ".*Datadog - Adminstrators.*|.*BoT Team.*|.*Datadog - Standard Role.*|.*Team.*|.*Product.*", "name": "memberOf", "namespace": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri", "type": "GROUP"}]
+    groups_assigned = [
+    {
+        name="Externals - Contractor - Major"
+        priority="0"
+    },
+    {
+        name="external-GSuiteAdminChampions"
+        priority="1"
+    },
+    ]
+}


### PR DESCRIPTION
You will find bellow the lists of command to import properly this terraform ressource
 Keep in mind for SWA application you will have to verify if there is a link to the Vault 

**Application command:**
 -Atlantis import okta_app_saml.application 0oa4yi7dc6Qu9yrJk0x7
**Group command:**
 -['Atlantis import okta_app_group_assignment.groups_assignedégroup_id 00g3u1dathPcB3pAS0x7', 'Atlantis import okta_app_group_assignment.groups_assignedégroup_id 00g5xfb15nrR98Q0Y0x7']
**Users command:**
 -No  direct users to import