### PR TITLE
Import of Back_Market_Support_Center

### DIFF
--- a/automation/dev/okta/application/terragrunt.hcl
+++ b/automation/dev/okta/application/terragrunt.hcl
@@ -1,0 +1,32 @@
+include {
+    path = find_in_parent_folders("env.hcl")
+}
+terraform {
+    source = "git::git@github.com:BackMarket/world-common.git//okta-applications-bookmark?ref=okta-applications-bookmark-1.1.0"
+
+}
+inputs = {
+    label = "Back Market Support Center"
+    logo = "./logo.png"
+    url = "https://backmarket.atlassian.net/servicedesk/customer/portals"
+    app_links_json = jsonencode({"login":true})
+    accessibility_self_service = false
+    auto_submit_toolbar = false
+    hide_ios = false
+    hide_web = false
+    users_assigned = ["jerome.heymonet@backmarket.com"]
+    groups_assigned = [
+      {
+          name="Externals - Helper"
+      
+      },
+      {
+          name="APP_Ext_Figma"
+      
+      },
+      {
+          name="APP_Ext_Example"
+      
+      },
+    ]
+}


### PR DESCRIPTION
You will find bellow the lists of command to import properly this terraform ressource
 Keep in mind for SWA application you will have to verify if there is a link to the Vault 

**Application command:**
 -Atlantis import okta_app_bookmark.application 0oa4ys9ejhcgGWSrh0x7
**Group command:**
 -['Atlantis import okta_app_group_assignment.groups_assigned ', 'Atlantis import okta_app_group_assignment.groups_assigned ', 'Atlantis import okta_app_group_assignment.groups_assigned ']
**Users command:**
 -['Atlantis import okta_app_user.users_assigned 0oa4ys9ejhcgGWSrh0x7/00u4dkk4mqH23P2TF0x7']